### PR TITLE
Fix collision of jdk configuration between the main job configuration and a Sonar task

### DIFF
--- a/src/main/resources/hudson/plugins/sonar/SonarPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/sonar/SonarPublisher/config.jelly
@@ -36,7 +36,7 @@
 
     <j:set var="jdks" value="${app.JDKs}" />
     <f:entry title="JDK" description="${%JDKDesc}" help="/plugin/sonar/help-sonar-jdk.html">
-      <select class="setting-input validated" name="jdk" checkUrl="'${rootURL}/defaultJDKCheck?value='+this.value">
+      <select class="setting-input validated" name="sonar.jdk" checkUrl="'${rootURL}/defaultJDKCheck?value='+this.value">
         <option>${%InheritFromJob}</option>
         <j:forEach var="inst" items="${jdks}">
           <f:option selected="${inst.name==instance.JDK.name}" value="${inst.name}">${inst.name}</f:option>

--- a/src/main/resources/hudson/plugins/sonar/SonarRunnerBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/sonar/SonarRunnerBuilder/config.jelly
@@ -27,7 +27,7 @@
   <!-- JDK -->
   <j:set var="jdks" value="${app.JDKs}" />
   <f:entry title="JDK" description="${%JDKDesc}" help="/plugin/sonar/help-sonar-jdk.html">
-    <select class="setting-input validated" name="jdk" checkUrl="'${rootURL}/defaultJDKCheck?value='+this.value">
+    <select class="setting-input validated" name="sonar.jdk" checkUrl="'${rootURL}/defaultJDKCheck?value='+this.value">
       <option>${%InheritFromJob}</option>
       <j:forEach var="inst" items="${jdks}">
         <f:option selected="${inst.name==instance.JDK.name}" value="${inst.name}">${inst.name}</f:option>


### PR DESCRIPTION
This pull-request fixes a bug which corrupts the job jdk field. The jdk field is overwritten with the value of the jdk of the sonar task which defaults to 'Hérite du job parent' in french. This breaks the build.

Fix is straightforward, it just adds the plugin name as a prefix for the jdk field in the jelly file.

Thanks for merging,
Yoann.