### PR TITLE
Sonarqube badge should be a link to the project page

### DIFF
--- a/src/main/resources/hudson/plugins/sonar/BuildSonarAction/badge.jelly
+++ b/src/main/resources/hudson/plugins/sonar/BuildSonarAction/badge.jelly
@@ -1,3 +1,5 @@
+<a href="it.url">
 <img width="16" height="16"
      title="${it.tooltip}" alt="[sonarqube]"
      src="${rootURL}${it.icon}"/>
+</a>


### PR DESCRIPTION
I love the little sonarqube badge that is added to the run history but I think it must be made more functional by making it a link to the SonarQube project.
Do you think it can be problematic?