### PR TITLE
Prevent loading all builds to generate the url

### DIFF
--- a/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
+++ b/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
@@ -39,7 +39,6 @@ import hudson.model.Run;
 import hudson.plugins.sonar.BuildSonarAction;
 import org.apache.commons.io.IOUtils;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -98,7 +97,11 @@ public final class SonarUtils {
   }
 
   @Nullable
-  private static String getSonarUrlFromRun(@Nonnull Run run) {
+  private static String getSonarUrlFromRun(Run run) {
+    if (run == null) {
+      return null;
+    }
+
     BuildSonarAction action = run.getAction(BuildSonarAction.class);
     if (action != null) {
       return action.getUrlName();

--- a/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
+++ b/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
@@ -39,7 +39,7 @@ import hudson.model.Run;
 import hudson.plugins.sonar.BuildSonarAction;
 import org.apache.commons.io.IOUtils;
 
-import javax.annotation.Nullable;
+import javax.annotation.CheckForNull;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.regex.Matcher;
@@ -96,7 +96,7 @@ public final class SonarUtils {
     }
   }
 
-  @Nullable
+  @CheckForNull
   private static String getSonarUrlFromRun(Run<?, ?> run) {
     if (run == null) {
       return null;

--- a/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
+++ b/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
@@ -97,7 +97,7 @@ public final class SonarUtils {
   }
 
   @Nullable
-  private static String getSonarUrlFromRun(Run run) {
+  private static String getSonarUrlFromRun(Run<?, ?> run) {
     if (run == null) {
       return null;
     }

--- a/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
+++ b/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
@@ -37,9 +37,10 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Run;
 import hudson.plugins.sonar.BuildSonarAction;
-import hudson.util.RunList;
 import org.apache.commons.io.IOUtils;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.regex.Matcher;
@@ -88,13 +89,21 @@ public final class SonarUtils {
    * Iterate previous build of this project and return the last Sonar URL
    */
   public static String getLastSonarUrl(AbstractProject<?, ?> project) {
-    RunList<? extends Run<?, ?>> builds = project.getBuilds();
-    for (Run<?, ?> run : builds) {
-      BuildSonarAction action = run.getAction(BuildSonarAction.class);
-      if (action != null) {
-        return action.getUrlName();
-      }
+    String url = getSonarUrlFromRun(project.getLastSuccessfulBuild());
+    if (url != null) {
+      return url;
+    } else {
+      return getSonarUrlFromRun(project.getLastUnstableBuild());
     }
-    return null;
+  }
+
+  @Nullable
+  private static String getSonarUrlFromRun(@Nonnull Run run) {
+    BuildSonarAction action = run.getAction(BuildSonarAction.class);
+    if (action != null) {
+      return action.getUrlName();
+    }
+
+    return  null;
   }
 }

--- a/src/test/java/hudson/plugins/sonar/utils/SonarUtilsTest.java
+++ b/src/test/java/hudson/plugins/sonar/utils/SonarUtilsTest.java
@@ -67,7 +67,7 @@ public class SonarUtilsTest {
     RunList list = mock(RunList.class);
     when(list.iterator()).thenReturn(Arrays.asList(build1, build2).iterator());
     when(project.getBuilds()).thenReturn(list);
-    assertThat(SonarUtils.getLastSonarUrl(project)).isEqualTo("http://foo");
+    assertThat(SonarUtils.getLastSonarUrl(project)).isNull();
   }
 
   private AbstractBuild<?, ?> mockedBuild(String log) throws IOException {

--- a/src/test/java/hudson/plugins/sonar/utils/SonarUtilsTest.java
+++ b/src/test/java/hudson/plugins/sonar/utils/SonarUtilsTest.java
@@ -37,12 +37,10 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Run;
 import hudson.plugins.sonar.BuildSonarAction;
-import hudson.util.RunList;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -60,13 +58,75 @@ public class SonarUtilsTest {
   }
 
   @Test
-  public void shouldGetLastUrl() throws Exception {
+  public void shouldGetLastSuccessfulBuildUrl() throws Exception {
+    // Given
     AbstractProject<?, ?> project = mock(AbstractProject.class);
-    Run<?, ?> build1 = mockedRunWithSonarAction(null);
-    Run<?, ?> build2 = mockedRunWithSonarAction("http://foo");
-    RunList list = mock(RunList.class);
-    when(list.iterator()).thenReturn(Arrays.asList(build1, build2).iterator());
-    when(project.getBuilds()).thenReturn(list);
+
+    // When
+    when(project.getLastSuccessfulBuild()).thenReturn(null);
+
+    // Then
+    assertThat(SonarUtils.getLastSonarUrl(project)).isNull();
+  }
+
+  @Test
+  public void getSuccessfulBuildWithValidUrl() throws Exception {
+    // Given
+    AbstractProject<?, ?> project = mock(AbstractProject.class);
+    AbstractBuild build = mock(AbstractBuild.class);
+
+    // When
+    String expectedUrl = "http://foo";
+    when(build.getAction(BuildSonarAction.class)).thenReturn(new BuildSonarAction(expectedUrl));
+    when(project.getLastSuccessfulBuild()).thenReturn(build);
+
+    // Then
+    assertThat(SonarUtils.getLastSonarUrl(project)).isEqualTo(expectedUrl);
+  }
+
+  @Test
+  public void successfulBuildWithoutSonarAction() throws Exception {
+    // Given
+    AbstractProject project = mock(AbstractProject.class);
+    AbstractBuild build = mock(AbstractBuild.class);
+
+    // When
+    when(build.getAction(BuildSonarAction.class)).thenReturn(null);
+    when(project.getLastSuccessfulBuild()).thenReturn(build);
+
+    // Then
+    assertThat(SonarUtils.getLastSonarUrl(project)).isNull();
+  }
+
+  @Test
+  public void getUnstableBuildUrlWhenNoStableBuild() throws Exception {
+    // Given
+    AbstractProject<?, ?> project = mock(AbstractProject.class);
+    AbstractBuild build = mock(AbstractBuild.class);
+
+    // When
+    when(project.getLastSuccessfulBuild()).thenReturn(null);
+
+    String expectedUrl = "http://foo";
+    when(build.getAction(BuildSonarAction.class)).thenReturn(new BuildSonarAction(expectedUrl));
+    when(project.getLastUnstableBuild()).thenReturn(build);
+
+    // Then
+    assertThat(SonarUtils.getLastSonarUrl(project)).isEqualTo(expectedUrl);
+  }
+
+  @Test
+  public void doNotUseUrlFromFailedBuild() throws Exception {
+    // Given
+    AbstractProject<?, ?> project = mock(AbstractProject.class);
+    AbstractBuild build = mock(AbstractBuild.class);
+
+    // When
+    when(project.getLastSuccessfulBuild()).thenReturn(null);
+    when(project.getLastUnstableBuild()).thenReturn(null);
+    when(project.getLastFailedBuild()).thenReturn(build);
+
+    // Then
     assertThat(SonarUtils.getLastSonarUrl(project)).isNull();
   }
 


### PR DESCRIPTION
In order to generate the url at the root project page it could be an expensive operation because it will iterate all of the builds in order to find a url. If a project has a lot of failed/aborted builds which never sent information to sonar (and a `BuildSonarAction` was never created), or if the project enabled sonar for the first time would most likely encounter a performance issue and load every build until it found a sonar url. Instead this pull request changes it to generate the url from the last stable or unstable build.

@reviewbybees