### PR TITLE
Fix sonar-jdk in post-build action (publisher)

### DIFF
--- a/src/main/resources/hudson/plugins/sonar/SonarPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/sonar/SonarPublisher/config.jelly
@@ -41,7 +41,7 @@
       <select class="setting-input validated" name="sonar.jdk" checkUrl="'${rootURL}/defaultJDKCheck?value='+this.value">
         <option value="">${%InheritFromJob}</option>
         <j:forEach var="inst" items="${jdks}">
-          <f:option selected="${inst.name==instance.JDK.name}" value="${inst.name}">${inst.name}</f:option>
+          <f:option selected="${inst.name==instance.getJdkName()}" value="${inst.name}">${inst.name}</f:option>
         </j:forEach>
       </select>
     </f:entry>


### PR DESCRIPTION
On edit config job, sonar-jdk in config.jelly doesn't match with actual sonar-jdk. On submit it will overwrite previous value with null (inherit from job), causing misconfiguration in job build.