### PR TITLE
Adding sonar.host.url in sonar properties

### DIFF
--- a/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerEnd.java
+++ b/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerEnd.java
@@ -109,6 +109,7 @@ public class MsBuildSQRunnerEnd extends AbstractMsBuildSQRunner {
   private static Map<String, String> getSonarProps(SonarInstallation inst) {
     Map<String, String> map = new LinkedHashMap<String, String>();
 
+    map.put("sonar.host.url", inst.getServerUrl());
     map.put("sonar.login", inst.getSonarLogin());
     map.put("sonar.password", inst.getSonarPassword());
 


### PR DESCRIPTION
Property sonar.host.url was not specified in "MSBuild SonarQube Runner End Analysis"