### PR TITLE
[JENKINS-33593] Upgrade to new plugin parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.580.3</version>
+    <version>2.3</version>
     <relativePath />
   </parent>
 
@@ -101,6 +101,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <hudson.version>${project.parent.version}</hudson.version>
     <sonar.exclusions>target/generated-sources/**/*</sonar.exclusions>
+    <jenkins.version>1.580.3</jenkins.version>
+    <java.level>6</java.level>
   </properties>
 
   <repositories>
@@ -121,8 +123,18 @@
       <!-- needed for SonarPublisher -->
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
-      <version>2.7.1</version>
+      <version>2.12.1</version>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+	       <groupId>org.apache.httpcomponents</groupId>
+	       <artifactId>httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+           <groupId>org.apache.httpcomponents</groupId>
+           <artifactId>httpcore</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -136,22 +148,17 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.10.8</version>
       <scope>test</scope>
-    </dependency>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>    
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
@@ -170,36 +177,23 @@
        <version>1.6</version>
        <scope>test</scope><!-- needed by git-server (via workflow-aggregator -> workflow-cps-global-lib) and otherwise unavailable during tests -->
      </dependency>
+     <dependency>
+      <groupId>org.jvnet.mock-javamail</groupId>
+      <artifactId>mock-javamail</artifactId>
+      <version>1.9</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.2</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.18</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <version>1.3.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.9</version>
-        </plugin>
         <plugin>
           <groupId>com.mycila.maven-license-plugin</groupId>
           <artifactId>maven-license-plugin</artifactId>
@@ -210,30 +204,16 @@
           <artifactId>maven-gpg-plugin</artifactId>
           <version>1.6</version>
         </plugin>
-        <plugin>
-          <groupId>org.jacoco</groupId>
-          <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.7.5.201505241946</version>
-        </plugin>
       </plugins>
     </pluginManagement>
 
     <plugins>
-      <plugin>
-        <groupId>org.jenkins-ci.tools</groupId>
-        <artifactId>maven-hpi-plugin</artifactId>
-        <configuration>
-          <!-- See http://jira.codehaus.org/browse/SONARPLUGINS-402 -->
-          <compatibleSinceVersion>1.2</compatibleSinceVersion>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <configuration>
           <localCheckout>true</localCheckout>
           <pushChanges>true</pushChanges>
-          <goals>deploy</goals>
         </configuration>
       </plugin>
       <plugin>
@@ -258,17 +238,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <systemPropertyVariables>
-            <!-- We should override default port defined in {@link hudson.UDPBroadcastThread#PORT} to avoid intersections 
-              with real Hudson on Nemo. -->
-            <hudson.udp>33849</hudson.udp>
-          </systemPropertyVariables>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
     <sonar.exclusions>target/generated-sources/**/*</sonar.exclusions>
     <jenkins.version>1.580.3</jenkins.version>
     <java.level>6</java.level>
+    <findbugs.failOnError>false</findbugs.failOnError>
   </properties>
 
   <repositories>

--- a/src/main/java/hudson/plugins/sonar/client/HttpClient.java
+++ b/src/main/java/hudson/plugins/sonar/client/HttpClient.java
@@ -21,6 +21,8 @@ package hudson.plugins.sonar.client;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 
+import com.google.common.base.Charsets;
+
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -37,12 +39,12 @@ public class HttpClient {
       if (!StringUtils.isEmpty(password)) {
         userpass = userpass + password;
       }
-      String basicAuth = "Basic " + javax.xml.bind.DatatypeConverter.printBase64Binary(userpass.getBytes(StandardCharsets.UTF_8));
+      String basicAuth = "Basic " + javax.xml.bind.DatatypeConverter.printBase64Binary(userpass.getBytes(Charsets.UTF_8));
       conn.setRequestProperty("Authorization", basicAuth);
     }
 
     conn.setRequestMethod("GET");
     InputStream is = conn.getInputStream();
-    return IOUtils.toString(is, StandardCharsets.UTF_8.name());
+    return IOUtils.toString(is, Charsets.UTF_8.name());
   }
 }

--- a/src/main/java/hudson/plugins/sonar/utils/MaskPasswordsOutputStream.java
+++ b/src/main/java/hudson/plugins/sonar/utils/MaskPasswordsOutputStream.java
@@ -36,6 +36,8 @@ package hudson.plugins.sonar.utils;
 import hudson.console.LineTransformationOutputStream;
 import org.apache.commons.lang.StringUtils;
 
+import com.google.common.base.Charsets;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -88,11 +90,11 @@ public class MaskPasswordsOutputStream extends LineTransformationOutputStream {
 
   @Override
   protected void eol(byte[] bytes, int len) throws IOException {
-    String line = new String(bytes, 0, len, StandardCharsets.UTF_8);
+    String line = new String(bytes, 0, len, Charsets.UTF_8);
     if (passwordsAsPattern != null && !line.contains(URL_IN_LOGS)) {
       line = passwordsAsPattern.matcher(line).replaceAll(REPLACEMENT);
     }
-    logger.write(line.getBytes(StandardCharsets.UTF_8));
+    logger.write(line.getBytes(Charsets.UTF_8));
   }
 
   @Override

--- a/src/main/resources/hudson/plugins/sonar/MsBuildSQRunnerBegin/config.jelly
+++ b/src/main/resources/hudson/plugins/sonar/MsBuildSQRunnerBegin/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
   <!-- ############ SonarQube Installation ############ -->

--- a/src/main/resources/hudson/plugins/sonar/MsBuildSQRunnerEnd/config.jelly
+++ b/src/main/resources/hudson/plugins/sonar/MsBuildSQRunnerEnd/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
 

--- a/src/main/resources/hudson/plugins/sonar/SonarBuildWrapper/config.jelly
+++ b/src/main/resources/hudson/plugins/sonar/SonarBuildWrapper/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
   <!-- SonarQube Installation -->

--- a/src/main/resources/hudson/plugins/sonar/SonarGlobalConfiguration/config.jelly
+++ b/src/main/resources/hudson/plugins/sonar/SonarGlobalConfiguration/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
          

--- a/src/main/resources/hudson/plugins/sonar/SonarGlobalConfiguration/triggers.jelly
+++ b/src/main/resources/hudson/plugins/sonar/SonarGlobalConfiguration/triggers.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 

--- a/src/main/resources/hudson/plugins/sonar/SonarPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/sonar/SonarPublisher/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 

--- a/src/main/resources/hudson/plugins/sonar/SonarPublisher/triggers.jelly
+++ b/src/main/resources/hudson/plugins/sonar/SonarPublisher/triggers.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 

--- a/src/main/resources/hudson/plugins/sonar/SonarRunnerBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/sonar/SonarRunnerBuilder/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
   <!-- SonarQube Installation -->

--- a/src/main/resources/hudson/plugins/sonar/action/SonarBuildBadgeAction/badge.jelly
+++ b/src/main/resources/hudson/plugins/sonar/action/SonarBuildBadgeAction/badge.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <a href="${it.urlName}">
 <img width="16" height="16"
      title="${it.tooltip}" alt="[sonarqube]"

--- a/src/main/resources/hudson/plugins/sonar/action/SonarProjectPageAction/jobMain.jelly
+++ b/src/main/resources/hudson/plugins/sonar/action/SonarProjectPageAction/jobMain.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<j:set var="projects" value="${it.getProjects()}" />
 	

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
 This view is used to render the installed plugins page.
 -->

--- a/src/test/java/hudson/plugins/sonar/SonarTestCase.java
+++ b/src/test/java/hudson/plugins/sonar/SonarTestCase.java
@@ -129,7 +129,7 @@ public abstract class SonarTestCase {
   }
 
   protected MavenModuleSet setupSonarMavenProject(String pomName) throws Exception {
-    MavenModuleSet project = j.createMavenProject("MavenProject");
+    final MavenModuleSet project = j.jenkins.createProject(MavenModuleSet.class, "MavenProject");
     // Setup SCM
     project.setScm(new SingleFileSCM(pomName, getClass().getResource("/hudson/plugins/sonar/SonarTestCase/pom.xml")));
     // Setup Maven

--- a/src/test/java/hudson/plugins/sonar/configurationslicing/SonarPublisherAdditionalPropertiesSlicerTest.java
+++ b/src/test/java/hudson/plugins/sonar/configurationslicing/SonarPublisherAdditionalPropertiesSlicerTest.java
@@ -55,7 +55,7 @@ public class SonarPublisherAdditionalPropertiesSlicerTest {
 
   @Test
   public void availableMavenProjectsWithSonarPublisher() throws IOException {
-    final MavenModuleSet project = j.createMavenProject();
+    final MavenModuleSet project = j.jenkins.createProject(MavenModuleSet.class, "random-name");
     assertThat(new SonarPublisherAdditionalPropertiesSlicer().getWorkDomain().size()).isZero();
     project.getPublishersList().add(new SonarPublisher("MySonar", null, null, "-Dsonar.verbose", null, null, null, null, null, null, false));
     assertThat(new SonarPublisherAdditionalPropertiesSlicer().getWorkDomain().size()).isEqualTo(1);
@@ -63,7 +63,7 @@ public class SonarPublisherAdditionalPropertiesSlicerTest {
 
   @Test
   public void changeJobAdditionalProperties() throws IOException {
-    final MavenModuleSet project = j.createMavenProject();
+    final MavenModuleSet project = j.jenkins.createProject(MavenModuleSet.class, "random-name");
     project.getPublishersList().add(new SonarPublisher("MySonar", null, null, "-Dsonar.verbose", null, null, null, null, null, null, false));
     final SonarPublisherAdditionalPropertiesSlicer.SonarPublisherAdditionalPropertiesSlicerSpec propertiesSpec = new SonarPublisherAdditionalPropertiesSlicer.SonarPublisherAdditionalPropertiesSlicerSpec();
     final List<String> values = propertiesSpec.getValues(project);

--- a/src/test/java/hudson/plugins/sonar/configurationslicing/SonarPublisherBranchSlicerTest.java
+++ b/src/test/java/hudson/plugins/sonar/configurationslicing/SonarPublisherBranchSlicerTest.java
@@ -55,7 +55,7 @@ public class SonarPublisherBranchSlicerTest {
 
   @Test
   public void availableMavenProjectsWithSonarPublisher() throws IOException {
-    final MavenModuleSet project = j.createMavenProject();
+    final MavenModuleSet project = j.jenkins.createProject(MavenModuleSet.class, "random-name");
     assertThat(new SonarPublisherBranchSlicer().getWorkDomain().size()).isZero();
     project.getPublishersList().add(new SonarPublisher("MySonar", null, null, null, null, null, null, null, null, null, false));
     assertThat(new SonarPublisherBranchSlicer().getWorkDomain().size()).isEqualTo(1);
@@ -63,7 +63,7 @@ public class SonarPublisherBranchSlicerTest {
 
   @Test
   public void changeJobAdditionalProperties() throws IOException {
-    final MavenModuleSet project = j.createMavenProject();
+    final MavenModuleSet project = j.jenkins.createProject(MavenModuleSet.class, "random-name");
     project.getPublishersList().add(new SonarPublisher("MySonar", null, null, null, null, null, null, null, null, null, false));
     final SonarPublisherBranchSlicer.SonarPublisherBranchSlicerSpec branchSpec = new SonarPublisherBranchSlicer.SonarPublisherBranchSlicerSpec();
     final List<String> values = branchSpec.getValues(project);

--- a/src/test/java/hudson/plugins/sonar/configurationslicing/SonarPublisherJdkSlicerTest.java
+++ b/src/test/java/hudson/plugins/sonar/configurationslicing/SonarPublisherJdkSlicerTest.java
@@ -55,7 +55,7 @@ public class SonarPublisherJdkSlicerTest {
 
   @Test
   public void availableMavenProjectsWithSonarPublisher() throws IOException {
-    final MavenModuleSet project = j.createMavenProject();
+    final MavenModuleSet project = j.jenkins.createProject(MavenModuleSet.class, "random-name");
     assertThat(new SonarPublisherJdkSlicer().getWorkDomain().size()).isZero();
     project.getPublishersList().add(new SonarPublisher("MySonar", null, null, null, null, null, null, null, null, null, false));
     assertThat(new SonarPublisherJdkSlicer().getWorkDomain().size()).isEqualTo(1);
@@ -63,7 +63,7 @@ public class SonarPublisherJdkSlicerTest {
 
   @Test
   public void changeJobAdditionalProperties() throws Exception {
-    final MavenModuleSet project = j.createMavenProject();
+    final MavenModuleSet project = j.jenkins.createProject(MavenModuleSet.class, "random-name");
     final SonarPublisher mySonar = new SonarPublisher("MySonar", null, null, null, null, null, null, "1.7", null, null, false);
     project.getPublishersList().add(mySonar);
 

--- a/src/test/java/hudson/plugins/sonar/configurationslicing/SonarPublisherSQServerSlicerTest.java
+++ b/src/test/java/hudson/plugins/sonar/configurationslicing/SonarPublisherSQServerSlicerTest.java
@@ -52,7 +52,7 @@ public class SonarPublisherSQServerSlicerTest {
 
   @Test
   public void availableMavenProjectsWithSonarPublisher() throws IOException {
-    final MavenModuleSet project = j.createMavenProject();
+    final MavenModuleSet project = j.jenkins.createProject(MavenModuleSet.class, "random-name");
     assertThat(new SonarPublisherSQServerSlicer().getWorkDomain().size()).isZero();
     project.getPublishersList().add(new SonarPublisher("MySonar", null, null, null, null, null, null, null, null, null, false));
     assertThat(new SonarPublisherSQServerSlicer().getWorkDomain().size()).isEqualTo(1);
@@ -60,7 +60,7 @@ public class SonarPublisherSQServerSlicerTest {
 
   @Test
   public void changeJobAdditionalProperties() throws Exception {
-    final MavenModuleSet project = j.createMavenProject();
+    final MavenModuleSet project = j.jenkins.createProject(MavenModuleSet.class, "random-name");
     final SonarPublisher mySonar = new SonarPublisher("MySonar", null, null, null, null, null, null, null, null, null, false);
     project.getPublishersList().add(mySonar);
 


### PR DESCRIPTION
Upgrade to new parent pom. Includes many improvements. More info [here](https://github.com/jenkinsci/plugin-pom)

- [x] Upgrade to new parent pom (version 2.3) keeping the same baseline version (1.580.3).
- [x] Fix minor issues found by animal-sniffer plugin.
- [x] Fix minor injected test issues after update to JTH 2.1

Upgrade to new plugin parent pom also integrates FindBug in the build. At the moment it is being ignored (see `properties`in pom.xml) because it finds too many issues to be addressed in this PR.

Apart from some plugin integrations that are useful to increase code quality, the new parent POM is decoupled from the core Jenkins project, both from the Maven and repository perspectives simplifying testing the plugin with different core versions. 

As an example, the Pipeline Plugin (formerly known as workflow) includes this since version [1.14](https://github.com/jenkinsci/workflow-plugin/tree/workflow-1.14).

